### PR TITLE
FIXED: removed unused server script, changed start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boilerplate-react-webpack",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A webpack React starter",
   "repository": "https://github.com/dev-academy-challenges/boilerplate-react-webpack.git",
   "main": "server/index.js",
@@ -11,9 +11,8 @@
     "dev": "run-p dev:client dev:server",
     "dev:client": "webpack --watch",
     "dev:server": "nodemon server",
-    "start": "run-s build server",
+    "start": "node server",
     "build": "webpack",
-    "server": "node server",
     "test": "jest --watchAll"
   },
   "babel": {


### PR DESCRIPTION
### In Heroku:
- build script is running twice
   1: before pruning dev dependencies
   2: when start script executes (will have an error as webpack won't exist anymore because of pruning)
